### PR TITLE
Add download of data

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "jquery": "^2.1.4",
     "leaflet": "^0.7.3",
     "lodash": "^3.1.0",
-    "octokat": "^0.4.10"
+    "octokat": "^0.4.10",
+    "shp-write": "^0.2.1"
   },
   "scripts": {
     "dev": "budo js/index.js:bundle.js --dir dist --live -- -t [ jstify --engine lodash ]",


### PR DESCRIPTION
This adds a button to download the filtered data as a SHP file.

Currently the file name is just "points" and the folder in the zip file is just "layers". Waiting on mapbox/shp-write#22

Trying to download all the points crashes Chrome right now. Probably some bug with mapbox/shp-write, or a bug in Chrome. It seems to work fine for smaller filtered downloads.
